### PR TITLE
Fix for camel case entity names

### DIFF
--- a/lib/entitiescreator.js
+++ b/lib/entitiescreator.js
@@ -212,7 +212,7 @@ EntitiesCreator.prototype.setBidirectionalRelationship = function(classId, injec
     relationshipId: this.entities[classId].relationships.length + 1,
     relationshipName: relationshipName.toLowerCase(),
     relationshipFieldName: relationshipName,
-    otherEntityName: this.parsedData.getClass(this.parsedData.getInjectedField(injectId).type).name.toLowerCase(),
+    otherEntityName: lowerCase(this.parsedData.getClass(this.parsedData.getInjectedField(injectId).type).name),
     relationshipType: this.parsedData.getInjectedField(injectId).cardinality
   };
 


### PR DESCRIPTION
When having a camel cased entity in the other side (for example **OrderLine**) the owner (for example CustomerOrder) has the **otherEntityName** is all lowercase, which breaks the java code which is generated.